### PR TITLE
Copy engines declaration into template

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -4,6 +4,9 @@
     "build": "iles build",
     "preview": "vite preview --open --port 5050"
   },
+  "engines": {
+    "node": "^14.0.0 || >= 16.0.0"
+  },
   "devDependencies": {
     "iles": "^0.6.0",
     "vite": "^2.6.13"


### PR DESCRIPTION
The project created by this initializer will require at least version 14
of node, so specify that in its `engines` declaration.

The system that I was trying this on still had node 12 as the default version, and when I attempted to run the created project it encountered import errors.