### PR TITLE
Revert "docs: direct questions to the #iles channel"

### DIFF
--- a/template/code/default/src/components/Welcome.vue
+++ b/template/code/default/src/components/Welcome.vue
@@ -38,7 +38,7 @@ import SupportIcon from './icons/IconSupport.vue'
     <template #heading>Community</template>
 
     Got stuck? Ask your question on the
-    <a target="_blank" href="https://discord.gg/fmSPNWvz">#iles channel</a> of the Vite.js Discord
+    <a target="_blank" href="https://discord.gg/PkbxgzPhJv">#ssr channel</a> of the Vite.js Discord
     server. Follow the
     <a target="_blank" href="https://twitter.com/ilesjs">@ilesjs</a>
     twitter account for latest news.


### PR DESCRIPTION
Reverts ElMassimo/create-iles#1 in favour of #2 which uses a permanent invite link.