### PR TITLE
fix: adjust recommended Volar extension id

### DIFF
--- a/template/base/.vscode/extensions.json
+++ b/template/base/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volar"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
Volar extension was migrated to Vue namespace

https://marketplace.visualstudio.com/items?itemName=Vue.volar