### PR TITLE
fix: update vscode ignore path

### DIFF
--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -17,7 +17,7 @@ dist-ssr
 /cypress/screenshots/
 
 # Editor directories and files
-.vscode
+.vscode/*
 !.vscode/extensions.json
 .idea
 *.suo


### PR DESCRIPTION
Current `.gitignore` rule to not ignore `extensions.json` does not work

<img width="502" alt="image" src="https://user-images.githubusercontent.com/1881266/180858235-0697d8dd-2818-4d4a-943c-ce446a1fad7a.png">

Updated `.gitignore`

<img width="512" alt="image" src="https://user-images.githubusercontent.com/1881266/180858324-9f6fcf2c-5170-4639-9051-a6757812a738.png">
